### PR TITLE
Ease adding anchors

### DIFF
--- a/grabber/anchors.py
+++ b/grabber/anchors.py
@@ -9,24 +9,27 @@ class Anchors(Points):
         coord = round(coord[0]), round(coord[1])
         grabber = self.metadata['grabber']
         
-        if self.is_valid(coord, on_contour=False):
+        if self.is_valid(coord):
             coord = self.closest_contour_point(coord)
             index = grabber.add(coord)
             self.data = np.insert(self.data, index, np.atleast_2d(coord), axis=0)
 
-    def is_valid(self, coord: Tuple[int, int], on_contour: bool) -> bool:
+    def is_valid(self, coord: Tuple[int, int]) -> bool:
         grabber = self.metadata['grabber']
         if grabber is None:
             return False
         y, x = grabber.costs.shape
-        return 0 <= coord[0] < y and 0 <= coord[1] < x and grabber.contour[coord] == on_contour
+        return 0 <= coord[0] < y and 0 <= coord[1] < x
+    
+    def is_on_contour(self, coord: Tuple[int, int]) -> bool:
+        grabber = self.metadata['grabber']
+        if grabber is None:
+            return False
+        return grabber.contour[coord] == True
 
     def closest_contour_point(self, coord) -> Tuple[int, int]:
         grabber = self.metadata['grabber']
-        contours, _ = cv2.findContours(grabber.contour.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
-        contour = sorted(contours, key=cv2.contourArea)[-1]
-        contour = contour.reshape((contour.shape[0], contour.shape[2]))
-        contour[:,[0, 1]] = contour[:,[1, 0]]
+        contour = np.array(np.nonzero(grabber.contour)).T
 
         closest_index = distance.cdist(contour, [coord]).argmin()
         coord = contour[closest_index]

--- a/grabber/anchors.py
+++ b/grabber/anchors.py
@@ -1,18 +1,35 @@
 from typing import Tuple
+import cv2
 import numpy as np
 from napari.layers.points import Points
-
+from scipy.spatial import distance
 
 class Anchors(Points):
     def add(self, coord: Tuple[int, int]) -> None:
         coord = round(coord[0]), round(coord[1])
         grabber = self.metadata['grabber']
-        y, x = grabber.costs.shape
-        if self.is_valid(coord, on_contour=True):
+        
+        if self.is_valid(coord, on_contour=False):
+            coord = self.closest_contour_point(coord)
             index = grabber.add(coord)
             self.data = np.insert(self.data, index, np.atleast_2d(coord), axis=0)
 
     def is_valid(self, coord: Tuple[int, int], on_contour: bool) -> bool:
         grabber = self.metadata['grabber']
+        if grabber is None:
+            return False
         y, x = grabber.costs.shape
         return 0 <= coord[0] < y and 0 <= coord[1] < x and grabber.contour[coord] == on_contour
+
+    def closest_contour_point(self, coord) -> Tuple[int, int]:
+        grabber = self.metadata['grabber']
+        contours, _ = cv2.findContours(grabber.contour.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
+        contour = sorted(contours, key=cv2.contourArea)[-1]
+        contour = contour.reshape((contour.shape[0], contour.shape[2]))
+        contour[:,[0, 1]] = contour[:,[1, 0]]
+
+        closest_index = distance.cdist(contour, [coord]).argmin()
+        coord = contour[closest_index]
+        coord = int(coord[0]), int(coord[1])
+
+        return coord

--- a/grabber/grabberwidget.py
+++ b/grabber/grabberwidget.py
@@ -113,7 +113,7 @@ class GrabberWidget(Container):
             # mouse move
             while event.type == 'mouse_move' and len(anchors.selected_data) == 1:
                 coords = round(anchors.position[-2]), round(anchors.position[-1])
-                if anchors.is_valid(coords, on_contour=False):
+                if anchors.is_valid(coords) and not anchors.is_on_contour(coords):
                     self._grabber.drag(coords)
                     self._contour_layer.data = self._grabber.contour
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     napari-plugin-engine>=0.1.4
     pyift>=0.0.4
     opencv-python-headless>=4.4.0
+    scipy>=1.7.2
 
 
 [options.entry_points] 


### PR DESCRIPTION
When adding anchors by clicking, the closest point on the contour is automatically selected as an anchor.
This avoids having to place a point exactly on the contour, which is often difficult in a zoomed out view.